### PR TITLE
[BUGFIX] 한국경제, 연합뉴스 기사 수집 안되던 문제 해결

### DIFF
--- a/src/main/java/com/team4/monew/entity/Article.java
+++ b/src/main/java/com/team4/monew/entity/Article.java
@@ -77,7 +77,14 @@ public class Article {
     this.originalLink = originalLink;
     this.title = title;
     this.publishedDate = publishedDate;
-    this.summary = (summary.length() > 140) ? summary.substring(0, 140) : summary;
+
+    String tempSummary = (summary != null) ? summary : "";
+    tempSummary = tempSummary.trim();
+    if (tempSummary.length() > 140) {
+      this.summary = tempSummary.substring(0, 140) + "...";
+    } else {
+      this.summary = tempSummary;
+    }
   }
 
   public void addInterest(Interest interest) {

--- a/src/main/java/com/team4/monew/entity/ArticleSource.java
+++ b/src/main/java/com/team4/monew/entity/ArticleSource.java
@@ -3,7 +3,7 @@ package com.team4.monew.entity;
 public enum ArticleSource {
   HANKYUNG("한국경제", "https://www.hankyung.com/feed/all-news"),
   CHOSUN("조선일보", "https://www.chosun.com/arc/outboundfeeds/rss/?outputType=xml"),
-  YONHAP("연합뉴스", "http://www.yonhapnewstv.co.kr/browse/feed/");
+  YONHAP("연합뉴스", "https://www.yna.co.kr/rss/news.xml");
 
   private final String source;
   private final String rssUrl;


### PR DESCRIPTION
description 필드가 없는 경우(ex. 한국경제), Article 엔티티 summary 컬럼에 빈 문자열 넣어주는 로직 추가했는데 이대로 유지해도 될까요? 확인 부탁드립니다!